### PR TITLE
Date: 09/04/2018

### DIFF
--- a/.idea/libraries/R_User_Library.xml
+++ b/.idea/libraries/R_User_Library.xml
@@ -1,0 +1,6 @@
+<component name="libraryTable">
+  <library name="R User Library">
+    <CLASSES />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Author: Jonathan R.

Commit of an updated Beam Deposition module. The following changes were added:

* Included ability to run beamdep.py as a stand alone script. The input is the data from shot 118890.1560. The values are hard coded in a debug version of the Core class and Inp class. These debug versions are classes defined within beamdep.py. The profiles are found in a debug file in ./inputs/ generated using an np.savetxt command of the ion and electron densities and temperatures.

* Deposition profiles have always been significantly off. When integrating over dPdr for all 3 beam types, we consistently underestimated the total power. This was addressed by multiplying by the integral of H(r) until we can figure out why this is necessary.

* Debug dictionary added to be able to plot various quantities of interest to see how changes to the code affect the results.